### PR TITLE
Fix SealedCreatureAsset not properly saving the template

### DIFF
--- a/ECCLibrary/ECCLibrary/Assets/SealedCreatureAsset.cs
+++ b/ECCLibrary/ECCLibrary/Assets/SealedCreatureAsset.cs
@@ -37,7 +37,7 @@ public sealed class SealedCreatureAsset : CreatureAsset
     /// <returns></returns>
     protected override CreatureTemplate CreateTemplate()
     {
-        return null;
+        return Template;
     }
 
     /// <summary>


### PR DESCRIPTION
It saves it to the field but that field is overwritten by the return value, which was null, meaning it's effectively not being saved